### PR TITLE
Removed Google Maps; centered contact-col.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -158,7 +158,10 @@ section {
 /** CONTACT **/
 
 .contact-col {
+    float: none;
+    margin: 0 auto;
     padding-top: 20px;
+    text-align: center;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -125,9 +125,6 @@
                     <hr>
                     <p><i class="fa fa-envelope" aria-hidden="true"></i>: <a href="mailto:ppd@thursdaynetwork.org">ppd@thursdaynetwork.org</a></p>
                 </div>
-                <div class="col-lg-7 contact-col map wow fadeInUp" data-wow-delay="0.3s">
-                    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3103.867937728686!2d-77.03424918470182!3d38.92699587956608!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7c818657635d3%3A0xa4af5257232650d!2sGreater+Washington+Urban+League!5e0!3m2!1sen!2sus!4v1495827393809" width="100%" height="300px" frameborder="0" style="border:0" allowfullscreen></iframe>
-                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Resolves Issue #24: Commit 441a7ff removes Google Maps frame from splash pages without being replaced by a placeholder (though one can be added... @impreze, maybe your banner?). This addresses styling until a frame from Mapbox can be inserted in place of the old Google Maps.  