### PR TITLE
Updated the target link for our github.

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                 <ul class="nav navbar-nav navbar-right" id="top-nav">
                     <li class="current"><a href="#"><i class="fa fa-home" aria-hidden="true"></i> Home</a></li>
                     <li><a href="https://www.thursdaynetwork.org/" target="_blank"><i class="fa fa-globe" aria-hidden="true"></i> Thursday Network</a></li>
-                    <li><a href="https://github.com/thursdaynetwork/HackTheManderDC" target="_blank"><i class="fa fa-github" aria-hidden="true"></i> Our Github</a></li>
+                    <li><a href="https://github.com/thursdaynetwork" target="_blank"><i class="fa fa-github" aria-hidden="true"></i> Our Github</a></li>
                     <li><a href="mailto:ppd@thursdaynetwork.org" target="_top"><i class="fa fa-envelope" aria-hidden="true"></i> Contact</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
Issue #42: Clicking on the "Our Github" button in the navbar now targets https://github.com/thursdaynetwork/UNhackthevote2017. 